### PR TITLE
fix: start date in campaign count stream

### DIFF
--- a/tap_instantly_ai/schemas/analytics_campaign_count.json
+++ b/tap_instantly_ai/schemas/analytics_campaign_count.json
@@ -47,6 +47,13 @@
                 "null"
             ]
         },
+        "start_date": {
+            "format": "date",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
         "downloaded_at": {
             "format": "timestamp",
             "type": [

--- a/tap_instantly_ai/streams.py
+++ b/tap_instantly_ai/streams.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 import typing as t
+import datetime
 
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
@@ -150,5 +151,25 @@ class AnalyticsCampaignCountStream(InstantlyAIStream):
             Dictionary of URL query parameters.
         """
         params = {}
-        params["start_date"] = self.config.get("start_date")
+        params["start_date"] = datetime.datetime.now().strftime("%Y-%m-%d")
+
         return params
+    
+    def post_process(
+        self,
+        row: dict,
+        context: dict | None = None,  # noqa: ARG002
+    ) -> dict | None:
+        """Post-process a row of data.
+
+        Args:
+            row: An individual record from the stream.
+            context: The stream context.
+
+        Returns:
+            The updated record dictionary, or ``None`` to skip the record.
+        """
+        updated_row = super().post_process(row, context)
+        updated_row["start_date"] = datetime.datetime.now().strftime("%Y-%m-%d")
+
+        return updated_row

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,17 +1,23 @@
 """Tests standard tap features using the built-in SDK tests library."""
 
+import datetime
 
-from singer_sdk.testing import get_tap_test_class
+from singer_sdk.testing import SuiteConfig, get_tap_test_class
 
 from tap_instantly_ai.tap import TapInstantlyAI
 
 SAMPLE_CONFIG = {
-    "start_date": "2024-01-01",
+    "start_date": datetime.datetime.now().strftime("%Y-%m-%d"),
 }
+
+TEST_SUITE_CONFIG = SuiteConfig(
+    ignore_no_records_for_streams=["analytics_campaign_count"]
+)
 
 # Run standard built-in tap tests from the SDK:
 TestTapInstantlyAI = get_tap_test_class(
     tap_class=TapInstantlyAI,
     config=SAMPLE_CONFIG,
+    suite_config=TEST_SUITE_CONFIG,
 )
 


### PR DESCRIPTION
Fix start date in CampaignAnalyticsCount stream, set start_date to current date, store it in schema and adjust test to handle zero results.